### PR TITLE
Use new privacy indicators for location

### DIFF
--- a/overlay/common/packages/apps/SimpleDeviceConfig/res/values/config.xml
+++ b/overlay/common/packages/apps/SimpleDeviceConfig/res/values/config.xml
@@ -23,5 +23,8 @@
         <!-- Enable privacy indicators -->
         <item>privacy/permissions_hub_2_enabled=true</item>
         <item>privacy/permissions_hub_enabled=true</item>
+
+        <!-- Use new privacy indicators for location -->
+        <item>privacy/location_indicators_enabled=true</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Android has had location indicators for a while, but let's use the new
privacy indicator infrastructure for displaying them. This makes them
integrate better with the new camera and microphone indicators.