### PR TITLE
vendor: Rename KERNEL_TOOLCHAIN_PREFIX_arm back to arm-linux-android-

### DIFF
--- a/config/BoardConfigKernel.mk
+++ b/config/BoardConfigKernel.mk
@@ -119,7 +119,7 @@ ifneq ($(KERNEL_NO_GCC), true)
     KERNEL_TOOLCHAIN_PREFIX_arm64 := aarch64-linux-android-
     # arm toolchain
     KERNEL_TOOLCHAIN_arm := $(GCC_PREBUILTS)/arm/arm-linux-androideabi-4.9/bin
-    KERNEL_TOOLCHAIN_PREFIX_arm := arm-linux-androidkernel-
+    KERNEL_TOOLCHAIN_PREFIX_arm := arm-linux-android-
     # x86 toolchain
     KERNEL_TOOLCHAIN_x86 := $(GCC_PREBUILTS)/x86/x86_64-linux-android-4.9/bin
     KERNEL_TOOLCHAIN_PREFIX_x86 := x86_64-linux-android-


### PR DESCRIPTION
This fix building the kernel with Clang-19 and higher.

Output:
make: Verzeichnis „/run/media/kevin/Daten/NLA/VoltageOS/kernel/nokia/msm8998“ wird betreten make[1]: Verzeichnis „/run/media/kevin/Daten/NLA/VoltageOS/out/target/product/NLA/obj/KERNEL_OBJ“ wird betreten
  GEN     ./Makefile
scripts/kconfig/conf  --silentoldconfig Kconfig
  CHK     include/config/kernel.release
  GEN     ./Makefile
  CHK     include/generated/uapi/linux/version.h
  CHK     scripts/mod/devicetable-offsets.h
  Using /run/media/kevin/Daten/NLA/VoltageOS/kernel/nokia/msm8998 as source for kernel
  CHK     include/generated/utsrelease.h
  CHK     include/generated/timeconst.h
  CHK     include/generated/bounds.h
  CHK     include/generated/asm-offsets.h
  CALL    /run/media/kevin/Daten/NLA/VoltageOS/kernel/nokia/msm8998/scripts/checksyscalls.sh
make[2]: „include/generated/vdso-offsets.h“ ist bereits aktuell.
  VDSOC32   arch/arm64/kernel/vdso32/vgettimeofday.o
  VDSOA32   arch/arm64/kernel/vdso32/sigreturn.o
clang: error: version 'kernel' in target triple 'arm-unknown-linux-androidkernel' is invalid
make[2]: *** [/run/media/kevin/Daten/NLA/VoltageOS/kernel/nokia/msm8998/arch/arm64/kernel/vdso32/Makefile:147: arch/arm64/kernel/vdso32/sigreturn.o] Error 1
make[2]: *** Es wird auf noch nicht beendete Prozesse gewartet …
clang: error: version 'kernel' in target triple 'arm-unknown-linux-androidkernel' is invalid
make[2]: *** [/run/media/kevin/Daten/NLA/VoltageOS/kernel/nokia/msm8998/arch/arm64/kernel/vdso32/Makefile:145: arch/arm64/kernel/vdso32/vgettimeofday.o] Error 1
make[1]: *** [arch/arm64/Makefile:210: vdso_prepare] Error 2
make[1]: Verzeichnis „/run/media/kevin/Daten/NLA/VoltageOS/out/target/product/NLA/obj/KERNEL_OBJ“ wird verlassen
make: *** [Makefile:152: sub-make] Error 2
make: Verzeichnis „/run/media/kevin/Daten/NLA/VoltageOS/kernel/nokia/msm8998“ wird verlassen